### PR TITLE
Override default trash command

### DIFF
--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -129,6 +129,9 @@ require('packer').startup(function(use)
 				},
 				filters = { custom = { '.git' } },
 				git = { ignore = false },
+				trash = {
+					cmd = 'trash',
+				},
 				view = {
 					mappings = {
 						list = {


### PR DESCRIPTION
A recent update to nvim-tree changed the default trash command to `gio trash`. This breaks configs relying on the command to be `trash`, e.g. from https://github.com/sindresorhus/trash-cli

Unfortunately this breaking change does not provide any warning to the user and if you continue to use `d` to "trash" files they will instead be perm deleted.